### PR TITLE
Fix Firefox and Safari

### DIFF
--- a/scripts/plugins/worker.ts
+++ b/scripts/plugins/worker.ts
@@ -45,7 +45,8 @@ export const WEB_WORKER = () => {
 
                         sourcemap: true,
                         assetNames: "[name]",
-                        format: "esm",
+                        // FIX: Firefox and Safari do not support Module workers
+                        format: "iife",
 
                         minify: true,
                         bundle: true,

--- a/src/editor/plugins/virtual-fs.ts
+++ b/src/editor/plugins/virtual-fs.ts
@@ -61,7 +61,7 @@ export const VIRTUAL_FS = (filename: string): Plugin => {
                     await init();
                     let tsContent = '';
                     try {
-                        tsContent = await transform(content, { internalURL: '/play/@astro/internal.min.js', sourcemap: 'inline', sourcefile: '/#' + filename }).then(res => res.code);
+                        tsContent = await transform(content, { internalURL: '/play/@astro/internal.min.js', sourcemap: false, sourcefile: '/#' + filename }).then(res => res.code);
                     } catch (e) {
                         console.log(e);
                     }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+    "cleanUrls": true,
+    "trailingSlash": false,
     "redirects": [
         {
             "source": "/",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+    "redirects": [
+        {
+            "source": "/",
+            "destination": "/play",
+            "permanent": false
+        }
+    ]
+}


### PR DESCRIPTION
FF and Safari don't support `type: "module"` with `new Worker()`, so we have to bundle those as `iife` modules.