### PR TITLE
Improve url compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "@astrojs/repl",
       "dependencies": {
+        "@amoutonbrady/lz-string": "^0.0.1",
         "@astrojs/compiler": "^0.1.0-canary.46",
         "assert": "^2.0.0",
         "browser-builtins": "^3.3.1",
@@ -32,6 +33,11 @@
         "prettier": "^2.4.0",
         "shorthash": "^0.0.2"
       }
+    },
+    "node_modules/@amoutonbrady/lz-string": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@amoutonbrady/lz-string/-/lz-string-0.0.1.tgz",
+      "integrity": "sha512-crH4ovRiiTg9y1lDTEtMwTdD4s/aYoz4EemUD3p+9GvHMOeJ3tUXQ/DQM1Mw9/wc9Od4jG97w0m9+gZmLysGFQ=="
     },
     "node_modules/@astrojs/compiler": {
       "version": "0.1.0-canary.46",
@@ -1692,6 +1698,11 @@
     }
   },
   "dependencies": {
+    "@amoutonbrady/lz-string": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@amoutonbrady/lz-string/-/lz-string-0.0.1.tgz",
+      "integrity": "sha512-crH4ovRiiTg9y1lDTEtMwTdD4s/aYoz4EemUD3p+9GvHMOeJ3tUXQ/DQM1Mw9/wc9Od4jG97w0m9+gZmLysGFQ=="
+    },
     "@astrojs/compiler": {
       "version": "0.1.0-canary.46",
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.1.0-canary.46.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "npx serve dist"
   },
   "dependencies": {
+    "@amoutonbrady/lz-string": "^0.0.1",
     "@astrojs/compiler": "^0.1.0-canary.46",
     "assert": "^2.0.0",
     "browser-builtins": "^3.3.1",

--- a/src/utils/b64.ts
+++ b/src/utils/b64.ts
@@ -1,9 +1,44 @@
+import { compressToURL, decompressFromURL } from '@amoutonbrady/lz-string'
+
+const PATH_PREFIX = 'inmemory://model/src';
+function serializeData(data: Record<string, string>): string {
+    let serialized = {};
+    for (const [key, value] of Object.entries(data)) {
+        serialized[key.slice(PATH_PREFIX.length)] = value.trim();
+    }
+    return JSON.stringify(serialized).slice(1, -1);
+}
+
+function deserializeData(data: string): Record<string, string> {
+    const tmp = JSON.parse(`{${data}}`);
+    let result = {};
+    for (const [key, value] of Object.entries(tmp)) {
+        result[`${PATH_PREFIX}${key}`] = value;
+    }
+    return result;
+}
+
 export function b64Encode(data: Record<string, string>) {
-    return btoa(encodeURIComponent(JSON.stringify(data)).replace(/%([0-9A-F]{2})/g, function(match, p1) {
-        return String.fromCharCode(('0x' + p1) as any);
-    }));
+    const value = compressToURL(serializeData(data));
+    return value;
+}
+
+export function legacyB64Decode(str: string) {
+    return decodeURIComponent(atob(str));
+}
+
+export function newB64Decode(str: string) {
+    let tmp = decompressFromURL(str);
+    if (!tmp) {
+        return null;
+    }
+    return tmp;
 }
 
 export function b64Decode(str: string) {
-    return JSON.parse(decodeURIComponent(atob(str)));
+    let value = newB64Decode(str);
+    if (!value) {
+        return JSON.parse(legacyB64Decode(str));
+    }
+    return deserializeData(value);
 }


### PR DESCRIPTION
With default content:
- base64 (previous): `2262` chars
- lzstring (new): `1126` chars

This is implemented in a backwards-compatible way! If we can't decompress the data with `lzstring` we assume it's base64 encoded and decode it with the old technique.